### PR TITLE
Modified Crosswalk definition to match Importer expectation

### DIFF
--- a/applications/registry/core/crosswalks/_crosswalk.php
+++ b/applications/registry/core/crosswalks/_crosswalk.php
@@ -6,4 +6,5 @@ abstract class Crosswalk
     abstract public function identify();
     abstract public function payloadToRIFCS($payload);
     abstract public function validate($payload);
+    abstract public function metadataFormat();
 }


### PR DESCRIPTION
applications/registry/core/libraries/importer.php expects a crosswalk
to have a validate($payload) method - see line 874 of that file.
