### PR TITLE
Doi legacy fix

### DIFF
--- a/htaccess.sample
+++ b/htaccess.sample
@@ -5,7 +5,8 @@ RewriteBase /
 
 RewriteRule ^services/ registry/ [R=301,L]
 
-RewriteRule ^apps/mydois/doi_(.*?)\.php apps/mydois/$1 [R=301,L,QSA]
+# ANDS-specific deploy rules (not needed in third-party deployment)
+# RewriteRule ^apps/mydois/doi_(.*?)\.php apps/mydois/$1 [R=301,L,QSA]
 
 RewriteCond $1 ^(css|img|js|less|lib|uploads|shared)
 RewriteRule ^assets/(.*?)/(.*)$ assets/$1/$2 [L]


### PR DESCRIPTION
Fix older URLs in DOIs.
Requires a 301 redirect to avoid CI getting confused between URLs. 
