### PR TITLE
CC-1294 Set auth_redirect using set_cookie, not setcookie

### DIFF
--- a/applications/portal/profile/controllers/profile.php
+++ b/applications/portal/profile/controllers/profile.php
@@ -251,12 +251,14 @@ class Profile extends MX_Controller
     {
         $this->load->helper('cookie');
         if (isset($_SERVER['HTTP_REFERER'])) {
-            setcookie("auth_redirect", $_SERVER['HTTP_REFERER'], time() + 3600, '/');
+            // CC-1294 Use "set_cookie", not "setcookie".
+            set_cookie("auth_redirect", $_SERVER['HTTP_REFERER'], time() + 3600);
         }
 
         if ($this->input->get('redirect')) {
             delete_cookie('auth_redirect');
-            setcookie('auth_redirect', $this->input->get('redirect'), time() + 3600, '/');
+            // CC-1294 Use "set_cookie", not "setcookie".
+            set_cookie('auth_redirect', $this->input->get('redirect'), time() + 3600);
         }
     }
 

--- a/engine/controllers/auth.php
+++ b/engine/controllers/auth.php
@@ -58,7 +58,8 @@ class Auth extends CI_Controller {
 		$this->load->helper('cookie');
 		delete_cookie('auth_redirect');
 		if ($this->input->get('redirect')) {
-			setcookie('auth_redirect', $this->input->get('redirect'), time()+3600, '/', $this->config->item('cookie_domain'));
+			// CC-1294 Use "set_cookie", not "setcookie".
+			set_cookie('auth_redirect', $this->input->get('redirect'), time()+3600);
 		}
 
 		$this->load->view('login', $data);


### PR DESCRIPTION
There was an inconsistency in the use of the auth_redirect cookie.
It was set with setcookie, but unset with delete_cookie.
delete_cookie uses the cookie_prefix, i.e., it was deleting a
cookie "ands_auth_redirect".  So, use set_cookie instead.