### PR TITLE
Vocabs CMS: CC-1347 Redo date fields

### DIFF
--- a/applications/portal/vocabs/assets/templates/versionModal.html
+++ b/applications/portal/vocabs/assets/templates/versionModal.html
@@ -42,16 +42,16 @@
                             </label>
 
                             <p class="input-group">
-                                <input required type="text" name="release_date" class="form-control"
-                                       ng-model="version.release_date" placeholder="Release Date"
-                                       datepicker-popup="yyyy-MM-dd" is-open="opened">
+                                <input required type="text" id="release_date" name="release_date" class="form-control"
+                                       ng-model="version.release_date" placeholder="Release Date (supported formats: YYYY-MM-DD, YYYY-MM, YYYY)"
+                                       datepicker-popup="yyyy-MM-dd" is-open="$parent.opened">
 									<span class="input-group-btn">
 										<button type="button" class="btn btn-default" ng-click="open($event)"><i
                                                 class="glyphicon glyphicon-calendar"></i></button>
 									</span>
                             </p>
                             <p ng-show="form.versionForm.release_date.$invalid" class="help-block">Release Date is
-                                required.</p>
+                                required. Supported formats: YYYY-MM-DD, YYYY-MM, YYYY.</p>
                         </div>
                         <div class="form-group">
                             <label for="">Notes

--- a/applications/portal/vocabs/views/cms.blade.php
+++ b/applications/portal/vocabs/views/cms.blade.php
@@ -103,8 +103,13 @@
 								<label for="">Vocabulary Creation Date
 									<span ng-bind-html="confluenceTip('VocabularyCreationDate')"></span>
 								</label>
-							    <input type="text" class="form-control" required name="creation_date" ng-model="vocab.creation_date" placeholder="Vocabulary Creation Date">
-								<p ng-show="form.cms.creation_date.$invalid" class="help-block">Vocabulary Creation Date is required.</p>
+								<p class="input-group">
+									<input type="text" id="creation_date" class="form-control" required name="creation_date" placeholder="Vocabulary Creation Date (supported formats: YYYY-MM-DD, YYYY-MM, YYYY)" ng-model="vocab.creation_date" datepicker-popup="yyyy-MM-dd" is-open="$parent.opened" >
+									<span class="input-group-btn">
+										<button type="button" class="btn btn-default" ng-click="open($event)"><i class="glyphicon glyphicon-calendar"></i></button>
+									</span>
+								</p>
+								<p ng-show="form.cms.creation_date.$invalid" class="help-block">Vocabulary Creation Date is required. Supported formats: YYYY-MM-DD, YYYY-MM, YYYY.</p>
 							</div>
 							<div class="form-group">
 								<label for="">Revision Cycle

--- a/etc/db/mysql/dbs_vocabs_r17_to_r18_incr.sql
+++ b/etc/db/mysql/dbs_vocabs_r17_to_r18_incr.sql
@@ -1,0 +1,1 @@
+ALTER TABLE versions DROP release_date;


### PR DESCRIPTION
Put back the date picker, but allow partial dates too
(YYYY, YYYY-MM) in the text field.
Make the creation date and release date behave the same way.